### PR TITLE
Make Event::getTotalForEvent static

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "lwc/kumite-pheasant",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "Pheasant integration for Kumite",
     "require-dev": {
         "phpunit/phpunit": "~3.7"

--- a/lib/Kumite/Pheasant/Event.php
+++ b/lib/Kumite/Pheasant/Event.php
@@ -42,7 +42,7 @@ class Event extends DomainObject
     }
 
 
-    public function getTotalForEvent($testKey, $variantKey, $eventKey)
+    public static function getTotalForEvent($testKey, $variantKey, $eventKey)
     {
         $sql = <<<SQL
             SELECT COUNT(DISTINCT participantid)


### PR DESCRIPTION
StorageAdapter expects Event::getTotalForEvent to be static.

![](http://www.standbyformindcontrol.com/wp-content/uploads/2013/02/JCVD-jean-claude-van-damme-33364524-245-245.gif?9d7bd4)
